### PR TITLE
abstract enum pagename

### DIFF
--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -266,11 +266,11 @@ class OptionsMenu extends Page
   #end
 }
 
-enum PageName
+enum abstract PageName(String)
 {
-  Options;
-  Controls;
-  Colors;
-  Mods;
-  Preferences;
+  var Options = "options";
+  var Controls = "controls";
+  var Colors = "colors";
+  var Mods = "mods";
+  var Preferences = "preferences";
 }


### PR DESCRIPTION
should make adding modded optionspages better and easier makes it so you dont have to leech off an unused PageName or write your own code for making modded options, helping with compatibility between mods.